### PR TITLE
Hashtag 6 (Caw function)

### DIFF
--- a/protos/caw.proto
+++ b/protos/caw.proto
@@ -61,3 +61,12 @@ message ProfileReply {
   repeated string followers = 1;
   repeated string following = 2;
 }
+
+message HashtagRequest {
+  string hashtag = 1; // the hashtag string (not including the # sign)
+}
+
+message HashtagReply {
+  Caw caw = 1; // the caw that was just posted with the hashtag
+}
+

--- a/protos/faz.proto
+++ b/protos/faz.proto
@@ -43,4 +43,5 @@ service FazService {
   rpc hook (HookRequest) returns (HookReply) {}
   rpc unhook (UnhookRequest) returns (UnhookReply) {}
   rpc event (EventRequest) returns (EventReply) {}
+  rpc streamEvent (EventRequest) returns (stream EventReply) {}
 }

--- a/src/caw/functions/caw_functions.h
+++ b/src/caw/functions/caw_functions.h
@@ -1,16 +1,15 @@
 #ifndef CAW_FUNCTIONS_
 #define CAW_FUNCTIONS_
 
-#include "caw.pb.h"
-
-#include <string>
-#include <vector>
-
 #include <glog/logging.h>
 #include <google/protobuf/any.pb.h>
 #include <grpcpp/grpcpp.h>
 
+#include <string>
+#include <vector>
+
 #include "../../key_value_store/KeyValueStoreInterface.h"
+#include "caw.pb.h"
 
 using google::protobuf::Any;
 using grpc::Channel;
@@ -24,6 +23,8 @@ using caw::CawReply;
 using caw::CawRequest;
 using caw::FollowReply;
 using caw::FollowRequest;
+using caw::HashtagReply;
+using caw::HashtagRequest;
 using caw::ProfileReply;
 using caw::ProfileRequest;
 using caw::ReadReply;
@@ -76,4 +77,13 @@ Status FollowUser(const Any &EventRequest, Any &EventReply,
 // Returns: Status indicating success / error message
 Status GetProfile(const Any &EventRequest, Any &EventReply,
                   KeyValueStoreInterface &kvstore);
+// streams Caws that contain the provided hashtag
+// Args: EventRequest: that contains a TagRequesst which contains the hashtag
+//       EventReply: that contains a ProfileReply
+//       std::function: callback function to execute when new Caw contains the
+//       provided hashtag
+// Returns: Status indicating success / error message
+Status StreamTag(const Any &EventRequest, Any &EventReply,
+                 KeyValueStoreInterface &kvstore,
+                 std::function<bool(std::string)> &);
 #endif

--- a/src/faz/client/cpp_client/faz_client.cpp
+++ b/src/faz/client/cpp_client/faz_client.cpp
@@ -26,6 +26,11 @@ Status FazClient::Event(Any request, Any *response, int eventType) {
   return status;
 }
 
+Status FazClient::StreamEvent(const Any request,
+                              ServerWriter<EventReply> *reply, int eventType) {
+  return Status::OK;
+}
+
 Status FazClient::HookFunction(int eventType, std::string functionName) {
   HookRequest request;
   HookReply response;

--- a/src/faz/client/cpp_client/faz_client.h
+++ b/src/faz/client/cpp_client/faz_client.h
@@ -1,21 +1,22 @@
 #ifndef FAZ_CLIENT_
 #define FAZ_CLIENT_
 
-#include "faz.grpc.pb.h"
+#include <glog/logging.h>
+#include <google/protobuf/any.pb.h>
+#include <grpcpp/grpcpp.h>
 
 #include <iostream>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
-#include <glog/logging.h>
-#include <google/protobuf/any.pb.h>
-#include <grpcpp/grpcpp.h>
+#include "faz.grpc.pb.h"
 
 using google::protobuf::Any;
 using grpc::Channel;
 using grpc::ClientContext;
 using grpc::ClientReaderWriter;
+using grpc::ServerWriter;
 using grpc::Status;
 
 using faz::EventReply;
@@ -42,6 +43,10 @@ class FazClient final {
   //       represent the input and output from our registered function
   // Returns: A grpc Status indicating success / failure
   Status Event(Any request, Any *response, int eventType);
+  // calls event function for events that need to be watched to see if there
+  // will be an update (similar to a pub sub functionality)
+  Status StreamEvent(const Any request, ServerWriter<EventReply> *reply,
+                     int eventType);
   // This method calls the Faz hook function. This is supposed to
   // hook a custom function to our FaaS.
   // Args: An event type that corresponds with the function call

--- a/src/faz/server/faz_server.cpp
+++ b/src/faz/server/faz_server.cpp
@@ -54,3 +54,8 @@ Status FazServiceImpl::event(ServerContext *context,
   }
   return status;
 }
+
+Status streamEvent(ServerContext *context, const EventRequest *request,
+                   ServerWriter<EventReply> *reply) {
+  return Status::OK;
+}

--- a/src/faz/server/faz_server.h
+++ b/src/faz/server/faz_server.h
@@ -16,6 +16,7 @@ using grpc::Server;
 using grpc::ServerBuilder;
 using grpc::ServerContext;
 using grpc::ServerReaderWriter;
+using grpc::ServerWriter;
 using grpc::Status;
 using grpc::StatusCode;
 
@@ -73,6 +74,10 @@ class FazServiceImpl final : public faz::FazService::Service {
   // Returns: GRPC Status indicating success/error
   Status event(ServerContext *context, const EventRequest *request,
                EventReply *response) override;
+
+  // stream events from server-side to client
+  Status streamEvent(ServerContext* context, const EventRequest* request,
+                      ServerWriter<EventReply>* reply) override;
 
  private:
   // This is a string -> function mapping of

--- a/src/key_value_store/client/kvstore_client.cpp
+++ b/src/key_value_store/client/kvstore_client.cpp
@@ -67,8 +67,9 @@ bool KeyValueStoreClient::Get(const std::string &tag,
   stream->WritesDone();
 
   GetReply response;
-  while (stream->Read(&response)) {
-    callback(response.value());  // might need to capture return value later
+  bool callback_response = true;  // false when need to exit function
+  while (stream->Read(&response) && callback_response) {
+    callback_response = callback(response.value());
   }
   Status status = stream->Finish();
   LOG(INFO) << status.error_code() << ": " << status.error_message();

--- a/tests/CawFunctionTests.cpp
+++ b/tests/CawFunctionTests.cpp
@@ -1,13 +1,12 @@
-#include "../src/caw/functions/caw_functions.h"
-#include "../src/key_value_store/core/KeyValueStore.h"
-
 #include <string>
 #include <vector>
 
+#include "../src/caw/functions/caw_functions.h"
+#include "../src/key_value_store/core/KeyValueStore.h"
 #include "gtest/gtest.h"
 
 KeyValueStore store;
-KeyValueStoreInterface &kvstore = store;
+KeyValueStoreInterface& kvstore = store;
 
 // Test to see if the caw function registers
 // a user properly
@@ -255,7 +254,28 @@ TEST(GetProfileTest, lessBasic_getprofile_test) {
   EXPECT_EQ(response.followers()[0], "Loan");
 }
 
-int main(int argc, char **argv) {
+//  tests streaming hashtag functionality
+TEST(StreamTagTest, hashtag_stream) {
+  const std::string kMessage = "message #tag1 and #tag2 and rest of message";
+  int count = 0;
+  Any EventRequest;
+  Any* EventReply = new Any();
+  HashtagRequest request;
+  HashtagRequest response;
+  request.set_hashtag("tag1");
+  EventRequest.PackFrom(request);
+  std::function<bool(std::string)> f1 = [&kMessage, &count](std::string m) {
+    EXPECT_EQ(kMessage, m);
+    count++;
+    return true;
+  };
+  Status status = StreamTag(EventRequest, *EventReply, kvstore, f1);
+  kvstore.Put("key1", kMessage);
+  EXPECT_EQ(1, count);
+  EXPECT_EQ(status.error_code(), 0);
+}
+
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Hi Fayez,

I added the Caw function and modified the kv client so that it will exit when the callback is false that will be passed from the Faz layer through the Caw layer into the kv client where it will be called.  This allows for testing to be independent of Caw functionality. 

  I did realize I do not have complete code coverage on the test due to lines 216 through 219 in `caw_functions.cpp` where an internal status code error is returned.  This is impossible to get in testing without the gRPC kvstore since there cannot be an internal error in the core version of kv.

Let me know if you have any questions!