### PR TITLE
Hashtag 7 (Modified stream tag and added faz backend functionality)

### DIFF
--- a/src/caw/functions/caw_functions.h
+++ b/src/caw/functions/caw_functions.h
@@ -79,11 +79,9 @@ Status GetProfile(const Any &EventRequest, Any &EventReply,
                   KeyValueStoreInterface &kvstore);
 // streams Caws that contain the provided hashtag
 // Args: EventRequest: that contains a TagRequesst which contains the hashtag
-//       EventReply: that contains a ProfileReply
 //       std::function: callback function to execute when new Caw contains the
 //       provided hashtag
 // Returns: Status indicating success / error message
-Status StreamTag(const Any &EventRequest, Any &EventReply,
-                 KeyValueStoreInterface &kvstore,
-                 std::function<bool(std::string)> &);
+Status StreamTag(const Any &EventRequest, KeyValueStoreInterface &kvstore,
+                 std::function<bool(Any &)> &callback);
 #endif

--- a/src/faz/server/faz_server.cpp
+++ b/src/faz/server/faz_server.cpp
@@ -5,12 +5,16 @@ Status FazServiceImpl::hook(ServerContext *context, const HookRequest *request,
   int eventType = request->event_type();
   std::string functionName = request->event_function();
   Status status;
-  // If the key does not exist
-  if (caw_functions_.find(functionName) == caw_functions_.end()) {
-    status = Status(StatusCode::NOT_FOUND, "The given function does not exist");
-  } else {
+  // If the key exists
+  if (caw_functions_.find(functionName) != caw_functions_.end()) {
     hooked_functions_[eventType] = functionName;
     status = Status::OK;
+  } else if ((caw_stream_functions_.find(functionName) !=
+              caw_stream_functions_.end())) {
+    hooked_functions_[eventType] = functionName;
+    status = Status::OK;
+  } else {  // the key does not exist
+    status = Status(StatusCode::NOT_FOUND, "The given function does not exist");
   }
   return status;
 }
@@ -55,7 +59,27 @@ Status FazServiceImpl::event(ServerContext *context,
   return status;
 }
 
-Status streamEvent(ServerContext *context, const EventRequest *request,
-                   ServerWriter<EventReply> *reply) {
-  return Status::OK;
+Status FazServiceImpl::streamEvent(ServerContext *context,
+                                   const EventRequest *request,
+                                   ServerWriter<EventReply> *response) {
+  int event_type = request->event_type();
+  Status status;
+  if (hooked_functions_.find(event_type) == hooked_functions_.end()) {
+    status =
+        Status(StatusCode::NOT_FOUND, "The given event type does not exist");
+  } else {
+    std::string function_name = hooked_functions_[event_type];
+    auto event_function = caw_stream_functions_[function_name];
+    // Function loads any into event reply and writes to client.  Write returns
+    // boolean based on success or failure.
+    std::function<bool(Any & response)> stream_writer_function =
+        [&response](Any &response_any) {
+          EventReply reply;
+          *(reply.mutable_payload()) = response_any;
+          return response->Write(reply);
+        };
+    status =
+        event_function(request->payload(), kvstore_, stream_writer_function);
+  }
+  return status;
 }

--- a/tests/CawFunctionTests.cpp
+++ b/tests/CawFunctionTests.cpp
@@ -257,20 +257,24 @@ TEST(GetProfileTest, lessBasic_getprofile_test) {
 //  tests streaming hashtag functionality
 TEST(StreamTagTest, hashtag_stream) {
   const std::string kMessage = "message #tag1 and #tag2 and rest of message";
+  Caw test_caw;
+  test_caw.set_text(kMessage);
+  std::string test_caw_serialized;
+  test_caw.SerializeToString(&test_caw_serialized);
   int count = 0;
   Any EventRequest;
-  Any* EventReply = new Any();
   HashtagRequest request;
-  HashtagRequest response;
   request.set_hashtag("tag1");
   EventRequest.PackFrom(request);
-  std::function<bool(std::string)> f1 = [&kMessage, &count](std::string m) {
-    EXPECT_EQ(kMessage, m);
+  std::function<bool(Any&)> f1 = [&kMessage, &count](Any& reply_any) {
+    HashtagReply hashtag_reply;
+    reply_any.UnpackTo(&hashtag_reply);
+    EXPECT_EQ(kMessage, hashtag_reply.caw().text());
     count++;
     return true;
   };
-  Status status = StreamTag(EventRequest, *EventReply, kvstore, f1);
-  kvstore.Put("key1", kMessage);
+  Status status = StreamTag(EventRequest, kvstore, f1);
+  kvstore.Put("sample caw", test_caw_serialized);
   EXPECT_EQ(1, count);
   EXPECT_EQ(status.error_code(), 0);
 }


### PR DESCRIPTION
Hi Fayez,

I realized that my last implementation of `StreamTag` in Caw Functions needed a wrapper callback to put the caw object in a HashtagReply before returning it up to the Faz layer.  This makes it so I can keep a generic streamEvent function at the Faz layer, and also by modifying the callback in the server backend it can now interpret the stream reply in any way it likes.  I realize the callback argument of an `Any` instead of an `EventReply` might not be perfect, so I might change this later if it becomes an issue.  

Thanks!